### PR TITLE
SWAP-1496 The beamtimes do not show up for the PI. They should show up and they should also show up for the co-proposer

### DIFF
--- a/src/datasources/postgres/ProposalBookingDataSource.ts
+++ b/src/datasources/postgres/ProposalBookingDataSource.ts
@@ -68,7 +68,7 @@ export default class PostgresProposalBookingDataSource
       .where('proposal_id', proposalId)
       .modify(qb => {
         if (filter?.status) {
-          qb.where('status', filter.status);
+          qb.whereIn('status', filter.status);
         }
       })
       .first();

--- a/src/resolvers/types/Proposal.ts
+++ b/src/resolvers/types/Proposal.ts
@@ -26,8 +26,8 @@ export class Proposal {
 
 @InputType()
 export class ProposalProposalBookingFilter {
-  @Field(() => ProposalBookingStatus, { nullable: true })
-  status?: ProposalBookingStatus | null;
+  @Field(() => [ProposalBookingStatus], { nullable: true })
+  status?: ProposalBookingStatus[] | null;
 }
 
 @Resolver(() => Proposal)
@@ -37,9 +37,11 @@ export class ProposalResolvers {
     @Ctx() ctx: ResolverContext,
     @Root() proposal: Proposal,
     @Arg('filter', () => ProposalProposalBookingFilter, {
-      defaultValue: { status: ProposalBookingStatus.BOOKED },
+      defaultValue: {
+        status: [ProposalBookingStatus.BOOKED, ProposalBookingStatus.CLOSED],
+      },
     })
-    filter: ProposalProposalBookingFilter
+    filter?: ProposalProposalBookingFilter
   ) {
     return ctx.queries.proposalBooking.getByProposalId(
       ctx,


### PR DESCRIPTION
## Description

This PR fixes the default filtering used to retrieve the proposal's beamtimes.
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, it filters for `BOOKED` by default.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test on the core side
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1496
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- filtering logic updated
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/293
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
