### PR TITLE
SWAP-1495 & SWAP-1493: Cleanup schedule steps, make the tabs clickable

### DIFF
--- a/src/buildContext.ts
+++ b/src/buildContext.ts
@@ -46,7 +46,10 @@ const equipmentQueries = new EquipmentQueries(
   equipmentDataSource,
   scheduledEventDataSource
 );
-const equipmentMutations = new EquipmentMutations(equipmentDataSource);
+const equipmentMutations = new EquipmentMutations(
+  equipmentDataSource,
+  proposalBookingDataSource
+);
 
 const context: BasicResolverContext = {
   isContext: true,


### PR DESCRIPTION
## Description

This PR fixes some bugs that could let the user add/remove equipment to/from a time slot, even though the proposal booking was in booked/closed state.
<!--- Describe your changes in detail -->

## Motivation and Context

Prevent the user from adding/removing equipment if the proposal booking isn't in a draft state.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] existing e2e test are passing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1495
https://jira.esss.lu.se/browse/SWAP-1493
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- disallow assigning or removing equipment to/from a time slot.
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-scheduler-frontend/pull/27
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
