### PR TITLE
Make schedulingevent filter mandatory and check for overlap between v…

### DIFF
--- a/src/datasources/postgres/ScheduledEventDataSource.ts
+++ b/src/datasources/postgres/ScheduledEventDataSource.ts
@@ -119,12 +119,12 @@ export default class PostgreScheduledEventDataSource
       .select()
       .where('instrument_id', filter.instrumentId);
 
-    if (filter.startsAt) {
-      qb.where('starts_at', '>=', filter.startsAt);
-    }
-
-    if (filter.endsAt) {
-      qb.where('ends_at', '<=', filter.endsAt);
+    if (filter.startsAt && filter.endsAt) {
+      qb.where('starts_at', '<=', filter.endsAt).andWhere(
+        'ends_at',
+        '>=',
+        filter.startsAt
+      );
     }
 
     const scheduledEventRecords = await qb;

--- a/src/resolvers/queries/ScheduledEventQuery.ts
+++ b/src/resolvers/queries/ScheduledEventQuery.ts
@@ -6,11 +6,11 @@ import { ScheduledEvent } from '../types/ScheduledEvent';
 
 @InputType()
 export class ScheduledEventFilter {
-  @Field(() => TzLessDateTime, { nullable: true })
-  startsAt?: Date | null;
+  @Field(() => TzLessDateTime)
+  startsAt: Date;
 
-  @Field(() => TzLessDateTime, { nullable: true })
-  endsAt?: Date | null;
+  @Field(() => TzLessDateTime)
+  endsAt: Date;
 
   @Field(() => ID, { nullable: true })
   instrumentId?: number | null;


### PR DESCRIPTION

## Description

At the moment a scheduling event that spans more than a week/month will not be visible in the views. This PR fixes the search by checking if a overlap between the view and a event exist

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
