### PR TITLE
SWAP-1948-use-new-queue-for-scheduler-communication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,9 +1575,9 @@
       }
     },
     "@esss-swap/duo-message-broker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-message-broker/-/duo-message-broker-1.0.7.tgz",
-      "integrity": "sha512-nr5vaN3oG0htYcwbhq2lFSaFhRgJXCZCnSEdn+eW2pQNqPer7ekIYLEm2uYubNAzaKBJ37L52TOe1olkapsv2A==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-message-broker/-/duo-message-broker-1.0.8.tgz",
+      "integrity": "sha512-/L6xcoLF6MHWcwDcFcXr+TWAm8QYZN+yhrYGGNa9LjQp9JAxu8f4dRcE+S9nd1lwPGm3+H8wtNioCdkjBqc1jg==",
       "requires": {
         "@esss-swap/duo-logger": "^1.0.3",
         "@types/amqplib": "^0.5.13",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@apollo/federation": "^0.33.0",
     "@esss-swap/duo-localisation": "^1.1.15",
     "@esss-swap/duo-logger": "^1.1.1",
-    "@esss-swap/duo-message-broker": "^1.0.7",
+    "@esss-swap/duo-message-broker": "^1.0.8",
     "@esss-swap/duo-validation": "^2.1.0",
     "apollo-graphql": "^0.9.3",
     "apollo-server": "^3.4.0",

--- a/src/eventHandlers/messageBroker.ts
+++ b/src/eventHandlers/messageBroker.ts
@@ -31,14 +31,17 @@ export function createListenToRabbitMQHandler({
     };
   }
 
-  rabbitMQ.listenOn(Queue.PROPOSAL, async (type, message) => {
+  rabbitMQ.listenOn(Queue.SCHEDULING_PROPOSAL, async (type, message) => {
     switch (type) {
       case Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW:
       case Event.PROPOSAL_STATUS_CHANGED_BY_USER:
-        logger.logDebug(`Listener on ${Queue.PROPOSAL}: Received event`, {
-          type,
-          message,
-        });
+        logger.logDebug(
+          `Listener on ${Queue.SCHEDULING_PROPOSAL}: Received event`,
+          {
+            type,
+            message,
+          }
+        );
         await proposalBookingDataSource.upsert(message);
 
         return;

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -415,7 +415,8 @@ export enum FeatureId {
   SHIPPING = 'SHIPPING',
   SCHEDULER = 'SCHEDULER',
   EXTERNAL_AUTH = 'EXTERNAL_AUTH',
-  RISK_ASSESSMENT = 'RISK_ASSESSMENT'
+  RISK_ASSESSMENT = 'RISK_ASSESSMENT',
+  EMAIL_INVITE = 'EMAIL_INVITE'
 }
 
 export type FieldCondition = {
@@ -617,8 +618,10 @@ export type Mutation = {
   createSampleEsi: SampleEsiResponseWrap;
   deleteSampleEsi: SampleEsiResponseWrap;
   updateSampleEsi: SampleEsiResponseWrap;
+  cloneSampleEsi: SampleEsiResponseWrap;
   createSample: SampleResponseWrap;
   updateSample: SampleResponseWrap;
+  cloneSample: SampleResponseWrap;
   assignChairOrSecretary: SepResponseWrap;
   assignReviewersToSEP: SepResponseWrap;
   removeMemberFromSep: SepResponseWrap;
@@ -660,7 +663,6 @@ export type Mutation = {
   applyPatches: PrepareDbResponseWrap;
   checkExternalToken: CheckExternalTokenWrap;
   cloneGenericTemplate: GenericTemplateResponseWrap;
-  cloneSample: SampleResponseWrap;
   cloneTemplate: TemplateResponseWrap;
   createEsi: EsiResponseWrap;
   createProposal: ProposalResponseWrap;
@@ -956,6 +958,13 @@ export type MutationUpdateSampleEsiArgs = {
 };
 
 
+export type MutationCloneSampleEsiArgs = {
+  esiId: Scalars['Int'];
+  sampleId: Scalars['Int'];
+  newSampleTitle?: Maybe<Scalars['String']>;
+};
+
+
 export type MutationCreateSampleArgs = {
   title: Scalars['String'];
   templateId: Scalars['Int'];
@@ -970,6 +979,13 @@ export type MutationUpdateSampleArgs = {
   title?: Maybe<Scalars['String']>;
   safetyComment?: Maybe<Scalars['String']>;
   safetyStatus?: Maybe<SampleStatus>;
+};
+
+
+export type MutationCloneSampleArgs = {
+  sampleId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  isPostProposalSubmission?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1273,12 +1289,6 @@ export type MutationCheckExternalTokenArgs = {
 export type MutationCloneGenericTemplateArgs = {
   title?: Maybe<Scalars['String']>;
   genericTemplateId: Scalars['Int'];
-};
-
-
-export type MutationCloneSampleArgs = {
-  title?: Maybe<Scalars['String']>;
-  sampleId: Scalars['Int'];
 };
 
 


### PR DESCRIPTION
## Description

fix: Added new SCHEDULED_PROPOSAL queue for communication between core and scheduler only

## Motivation and Context

Previously we were using Queue.PROPOSAL for communication between core and scheduler but scichat consumes that queue as well which is a bit of a problem with rabbitMQ that direct message strategy is using round robin algorithm to send messages to consumers. So not every message was sent to every consumer this is why we open new queue.

## Fixes

https://jira.esss.lu.se/browse/SWAP-1948
