### PR TITLE
feat: Add possibility to change equipment owner

### DIFF
--- a/src/datasources/EquipmentDataSource.ts
+++ b/src/datasources/EquipmentDataSource.ts
@@ -13,6 +13,7 @@ import {
   DeleteEquipmentAssignmentInput,
   ConfirmEquipmentAssignmentInput,
   EquipmentResponsibleInput,
+  UpdateEquipmentOwnerInput,
 } from '../resolvers/mutations/EquipmentMutation';
 
 export interface EquipmentDataSource {
@@ -47,6 +48,9 @@ export interface EquipmentDataSource {
   ): Promise<boolean>;
   addEquipmentResponsible(
     addEquipmentResponsibleInput: EquipmentResponsibleInput
+  ): Promise<boolean>;
+  updateEquipmentOwner(
+    updateEquipmentOwnerInput: UpdateEquipmentOwnerInput
   ): Promise<boolean>;
   getEquipmentResponsible(equipmentId: number): Promise<EquipmentResponsible[]>;
   equipmentEventsByProposalBookingId(

--- a/src/datasources/postgres/EquipmentDataSource.ts
+++ b/src/datasources/postgres/EquipmentDataSource.ts
@@ -13,6 +13,7 @@ import {
   DeleteEquipmentAssignmentInput,
   ConfirmEquipmentAssignmentInput,
   EquipmentResponsibleInput,
+  UpdateEquipmentOwnerInput,
 } from '../../resolvers/mutations/EquipmentMutation';
 import { EquipmentDataSource } from '../EquipmentDataSource';
 import database, { UNIQUE_CONSTRAINT_VIOLATION } from './database';
@@ -296,6 +297,17 @@ export default class PostgresEquipmentDataSource
       .returning('*');
 
     return deletedRecords.length === 1;
+  }
+
+  async updateEquipmentOwner(
+    input: UpdateEquipmentOwnerInput
+  ): Promise<boolean> {
+    const [equipmentRecord] = await database<EquipmentRecord>(this.tableName)
+      .update({ owner_id: input.userId })
+      .where({ equipment_id: input.equipmentId })
+      .returning('*');
+
+    return equipmentRecord.owner_id === input.userId;
   }
 
   async addEquipmentResponsible(

--- a/src/mutations/EquipmentMutations.ts
+++ b/src/mutations/EquipmentMutations.ts
@@ -15,6 +15,7 @@ import {
   DeleteEquipmentAssignmentInput,
   ConfirmEquipmentAssignmentInput,
   EquipmentResponsibleInput,
+  UpdateEquipmentOwnerInput,
 } from '../resolvers/mutations/EquipmentMutation';
 import { Roles, User } from '../types/shared';
 
@@ -120,13 +121,20 @@ export default class EquipmentMutations {
   }
 
   @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST]) // TODO: make sure we use the right permissions
+  async updateEquipmentOwner(
+    ctx: ResolverContext,
+    updateEquipmentOwnerInput: UpdateEquipmentOwnerInput
+  ) {
+    return this.equipmentDataSource.updateEquipmentOwner(
+      updateEquipmentOwnerInput
+    );
+  }
+
+  @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST]) // TODO: make sure we use the right permissions
   async addEquipmentResponsible(
     ctx: ResolverContext,
     equipmentResponsibleInput: EquipmentResponsibleInput
   ) {
-    // TODO: check if has permission
-    //  assignEquipmentsToScheduledEventInput.proposalBookingId
-
     return this.equipmentDataSource.addEquipmentResponsible(
       equipmentResponsibleInput
     );

--- a/src/resolvers/mutations/EquipmentMutation.ts
+++ b/src/resolvers/mutations/EquipmentMutation.ts
@@ -80,6 +80,15 @@ export class EquipmentResponsibleInput {
   userIds: number[];
 }
 
+@InputType()
+export class UpdateEquipmentOwnerInput {
+  @Field(() => Int)
+  equipmentId: number;
+
+  @Field(() => Int)
+  userId: number;
+}
+
 @Resolver()
 export class EquipmentMutation {
   @Mutation(() => EquipmentResponseWrap)
@@ -146,6 +155,18 @@ export class EquipmentMutation {
     return ctx.mutations.equipment.confirmAssignment(
       ctx,
       confirmEquipmentAssignmentInput
+    );
+  }
+
+  @Mutation(() => Boolean)
+  updateEquipmentOwner(
+    @Ctx() ctx: ResolverContext,
+    @Arg('updateEquipmentOwnerInput', () => UpdateEquipmentOwnerInput)
+    updateEquipmentOwnerInput: UpdateEquipmentOwnerInput
+  ): Promise<boolean> {
+    return ctx.mutations.equipment.updateEquipmentOwner(
+      ctx,
+      updateEquipmentOwnerInput
     );
   }
 


### PR DESCRIPTION
## Description

Added the possibility to change the equipment owner if you are user officer.

## Motivation and Context

Previously the owner was set on equipment creation and there was no way to change it.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1957

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
