### PR TITLE
SWAP-2079-proposal-booking-modal-refactor

### DIFF
--- a/src/buildContext.ts
+++ b/src/buildContext.ts
@@ -51,7 +51,8 @@ const equipmentQueries = new EquipmentQueries(
 );
 const equipmentMutations = new EquipmentMutations(
   equipmentDataSource,
-  proposalBookingDataSource
+  proposalBookingDataSource,
+  scheduledEventDataSource
 );
 
 const context: BasicResolverContext = {

--- a/src/datasources/index.ts
+++ b/src/datasources/index.ts
@@ -1,12 +1,12 @@
 import PostgresEquipmentDataSource from './postgres/EquipmentDataSource';
 import PostgresLostTimeDataSource from './postgres/LostTimeDataSource';
 import PostgresProposalBookingDataSource from './postgres/ProposalBookingDataSource';
-import PostgreScheduledEventDataSource from './postgres/ScheduledEventDataSource';
-import PostgreSystemDataSource from './postgres/SystemDataSource';
+import PostgresScheduledEventDataSource from './postgres/ScheduledEventDataSource';
+import PostgresSystemDataSource from './postgres/SystemDataSource';
 
 export const equipmentDataSource = new PostgresEquipmentDataSource();
 export const lostTimeDataSource = new PostgresLostTimeDataSource();
 export const proposalBookingDataSource =
   new PostgresProposalBookingDataSource();
-export const scheduledEventDataSource = new PostgreScheduledEventDataSource();
-export const systemDataSource = new PostgreSystemDataSource();
+export const scheduledEventDataSource = new PostgresScheduledEventDataSource();
+export const systemDataSource = new PostgresSystemDataSource();

--- a/src/mutations/EquipmentMutations.ts
+++ b/src/mutations/EquipmentMutations.ts
@@ -4,6 +4,7 @@ import { equipmentValidationSchema } from '@user-office-software/duo-validation'
 import { ResolverContext } from '../context';
 import { EquipmentDataSource } from '../datasources/EquipmentDataSource';
 import { ProposalBookingDataSource } from '../datasources/ProposalBookingDataSource';
+import { ScheduledEventDataSource } from '../datasources/ScheduledEventDataSource';
 import Authorized from '../decorators/Authorized';
 import ValidateArgs from '../decorators/ValidateArgs';
 import { ProposalBookingStatusCore } from '../generated/sdk';
@@ -22,7 +23,8 @@ import { Roles, User } from '../types/shared';
 export default class EquipmentMutations {
   constructor(
     private equipmentDataSource: EquipmentDataSource,
-    private proposalBookingDataSource: ProposalBookingDataSource
+    private proposalBookingDataSource: ProposalBookingDataSource,
+    private scheduledEventDataSource: ScheduledEventDataSource
   ) {}
 
   @ValidateArgs(equipmentValidationSchema)
@@ -66,10 +68,15 @@ export default class EquipmentMutations {
       assignEquipmentsToScheduledEventInput.proposalBookingId
     );
 
+    const scheduledEvent = await this.scheduledEventDataSource.get(
+      assignEquipmentsToScheduledEventInput.scheduledEventId
+    );
+
     if (
       !proposalBooking ||
-      // if the booking is not in DRAFT state disallow assigning any equipment
-      proposalBooking.status !== ProposalBookingStatusCore.DRAFT
+      !scheduledEvent ||
+      // if the scheduled event is not DRAFT state disallow assigning any equipment
+      scheduledEvent.status !== ProposalBookingStatusCore.DRAFT
     ) {
       return false;
     }
@@ -91,10 +98,15 @@ export default class EquipmentMutations {
       deleteEquipmentAssignmentInput.proposalBookingId
     );
 
+    const scheduledEvent = await this.scheduledEventDataSource.get(
+      deleteEquipmentAssignmentInput.scheduledEventId
+    );
+
     if (
       !proposalBooking ||
-      // if the booking is not in DRAFT state disallow delete any assigned equipment
-      proposalBooking.status !== ProposalBookingStatusCore.DRAFT
+      !scheduledEvent ||
+      // if the scheduled event is not DRAFT state disallow delete any assigned equipment
+      scheduledEvent.status !== ProposalBookingStatusCore.DRAFT
     ) {
       return false;
     }


### PR DESCRIPTION
## Description

Improve some checks for reopening and assigning equipment to experiment time. Previously equipment was more connected to the proposal booking but now it is with experiment time that's why we should check the status of the experiment not the proposal booking general status.

## How Has This Been Tested

- manual tests
- e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2079

## Changes

https://user-images.githubusercontent.com/6333063/148942943-bead40e4-6e50-4edc-b851-48258cd21049.mp4

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
