### PR TITLE
feat: Equipment should have instruments it could be used with

### DIFF
--- a/db_patches/0012_AddEquipmentInstrumentsTable.sql
+++ b/db_patches/0012_AddEquipmentInstrumentsTable.sql
@@ -1,0 +1,22 @@
+DO
+$DO$
+BEGIN
+  IF register_patch('AddEquipmentInstrumentsTable.sql', 'Martin Trajanovski', 'Connection between equipment and instruments that this equipment can be assigned to', '2022-01-31 10:30:00.000000+00') THEN
+  BEGIN
+
+    CREATE TABLE "equipment_instruments" (
+      "equipment_id" int NOT NULL
+      , "instrument_id" int NOT NULL
+      , PRIMARY KEY("equipment_id", "instrument_id")
+    );
+
+    ALTER TABLE "equipment_instruments" ADD CONSTRAINT equipment_instruments_equipment_id_fkey
+      FOREIGN KEY ("equipment_id") 
+      REFERENCES "equipments" ("equipment_id")
+      ON DELETE CASCADE;
+
+  END;
+  END IF;
+END;
+$DO$
+LANGUAGE plpgsql;

--- a/src/datasources/EquipmentDataSource.ts
+++ b/src/datasources/EquipmentDataSource.ts
@@ -1,6 +1,7 @@
 import {
   Equipment,
   EquipmentAssignmentStatus,
+  EquipmentInstrument,
   EquipmentResponsible,
 } from '../models/Equipment';
 import {
@@ -53,6 +54,7 @@ export interface EquipmentDataSource {
     updateEquipmentOwnerInput: UpdateEquipmentOwnerInput
   ): Promise<boolean>;
   getEquipmentResponsible(equipmentId: number): Promise<EquipmentResponsible[]>;
+  getEquipmentInstruments(equipmentId: number): Promise<EquipmentInstrument[]>;
   equipmentEventsByProposalBookingId(
     proposalBookingId: number
   ): Promise<Array<EquipmentsScheduledEvent>>;

--- a/src/datasources/EquipmentDataSource.ts
+++ b/src/datasources/EquipmentDataSource.ts
@@ -8,6 +8,7 @@ import {
   EquipmentsScheduledEvent,
   ScheduledEvent,
 } from '../models/ScheduledEvent';
+import { Rejection } from '../rejection';
 import {
   EquipmentInput,
   AssignEquipmentsToScheduledEventInput,
@@ -22,7 +23,7 @@ export interface EquipmentDataSource {
   update(
     id: number,
     updateEquipmentInput: EquipmentInput
-  ): Promise<Equipment | null>;
+  ): Promise<Equipment | Rejection | null>;
   get(id: number): Promise<Equipment | null>;
   getAll(equipmentIds?: number[]): Promise<Equipment[]>;
   getAllUserEquipments(

--- a/src/datasources/postgres/EquipmentDataSource.ts
+++ b/src/datasources/postgres/EquipmentDataSource.ts
@@ -66,14 +66,16 @@ export default class PostgresEquipmentDataSource
         })
         .returning('*');
 
-      await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
-        .insert(
-          instrumentIds.map((instrumentId) => ({
-            equipment_id: equipmentRecord.equipment_id,
-            instrument_id: instrumentId,
-          }))
-        )
-        .returning<EquipmentInstrumentRecord[]>(['*']);
+      if (instrumentIds?.length) {
+        await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+          .insert(
+            instrumentIds.map((instrumentId) => ({
+              equipment_id: equipmentRecord.equipment_id,
+              instrument_id: instrumentId,
+            }))
+          )
+          .returning<EquipmentInstrumentRecord[]>(['*']);
+      }
 
       return equipmentRecord;
     });
@@ -99,15 +101,17 @@ export default class PostgresEquipmentDataSource
           .where('equipment_id', '=', id)
           .delete();
 
-        // Re-create updated equipment instruments
-        await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
-          .insert(
-            instrumentIds.map((instrumentId) => ({
-              equipment_id: id,
-              instrument_id: instrumentId,
-            }))
-          )
-          .returning<EquipmentInstrumentRecord[]>(['*']);
+        if (instrumentIds?.length) {
+          // Re-create updated equipment instruments
+          await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+            .insert(
+              instrumentIds.map((instrumentId) => ({
+                equipment_id: id,
+                instrument_id: instrumentId,
+              }))
+            )
+            .returning<EquipmentInstrumentRecord[]>(['*']);
+        }
 
         // Update equipment itself
         const [equipmentRecord] = await trx<EquipmentRecord>(this.tableName)

--- a/src/datasources/postgres/EquipmentDataSource.ts
+++ b/src/datasources/postgres/EquipmentDataSource.ts
@@ -1,6 +1,10 @@
+import { logger } from '@user-office-software/duo-logger';
+import { ApolloError } from 'apollo-server';
+
 import {
   Equipment,
   EquipmentAssignmentStatus,
+  EquipmentInstrument,
   EquipmentResponsible,
 } from '../../models/Equipment';
 import {
@@ -24,6 +28,9 @@ import {
   EquipmentsScheduledEventsRecord,
   EquipmentResponsibleRecord,
   createEquipmentResponsibleObject,
+  createEquipmentInstrumentObject,
+  EquipmentInstrumentRecord,
+  ScheduledEventRecord,
 } from './records';
 
 export default class PostgresEquipmentDataSource
@@ -33,35 +40,98 @@ export default class PostgresEquipmentDataSource
   readonly scheduledEventsTable = 'scheduled_events';
   readonly scheduledEventsEquipmentsTable = 'scheduled_events_equipments';
   readonly equipmentResponsibleTable = 'equipment_responsible';
+  readonly equipmentInstrumentsTable = 'equipment_instruments';
 
   async create(userId: number, input: EquipmentInput): Promise<Equipment> {
-    const [equipmentRecord] = await database<EquipmentRecord>(this.tableName)
-      .insert({
-        owner_id: userId,
-        name: input.name,
-        description: input.description,
-        color: input.color,
-        maintenance_starts_at: input.maintenanceStartsAt,
-        maintenance_ends_at: input.maintenanceEndsAt,
-        auto_accept: input.autoAccept,
-      })
-      .returning('*');
+    const equipmentRecord = await database.transaction(async (trx) => {
+      const {
+        name,
+        description,
+        color,
+        maintenanceStartsAt,
+        maintenanceEndsAt,
+        autoAccept,
+        instrumentIds,
+      } = input;
+
+      const [equipmentRecord] = await trx<EquipmentRecord>(this.tableName)
+        .insert({
+          owner_id: userId,
+          name: name,
+          description: description,
+          color: color,
+          maintenance_starts_at: maintenanceStartsAt,
+          maintenance_ends_at: maintenanceEndsAt,
+          auto_accept: autoAccept,
+        })
+        .returning('*');
+
+      await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+        .insert(
+          instrumentIds.map((instrumentId) => ({
+            equipment_id: equipmentRecord.equipment_id,
+            instrument_id: instrumentId,
+          }))
+        )
+        .returning<EquipmentInstrumentRecord[]>(['*']);
+
+      return equipmentRecord;
+    });
 
     return createEquipmentObject(equipmentRecord);
   }
 
   async update(id: number, input: EquipmentInput): Promise<Equipment | null> {
-    const [equipmentRecord] = await database<EquipmentRecord>(this.tableName)
-      .update({
-        name: input.name,
-        description: input.description,
-        color: input.color,
-        maintenance_starts_at: input.maintenanceStartsAt,
-        maintenance_ends_at: input.maintenanceEndsAt,
-        auto_accept: input.autoAccept,
+    const equipmentRecord = await database
+      .transaction(async (trx) => {
+        const {
+          name,
+          description,
+          color,
+          maintenanceStartsAt,
+          maintenanceEndsAt,
+          autoAccept,
+          instrumentIds,
+        } = input;
+
+        // Delete existing equipment instruments
+        await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+          .where('equipment_id', '=', id)
+          .delete();
+
+        // Re-create updated equipment instruments
+        await trx<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+          .insert(
+            instrumentIds.map((instrumentId) => ({
+              equipment_id: id,
+              instrument_id: instrumentId,
+            }))
+          )
+          .returning<EquipmentInstrumentRecord[]>(['*']);
+
+        // Update equipment itself
+        const [equipmentRecord] = await trx<EquipmentRecord>(this.tableName)
+          .update({
+            name: name,
+            description: description,
+            color: color,
+            maintenance_starts_at: maintenanceStartsAt,
+            maintenance_ends_at: maintenanceEndsAt,
+            auto_accept: autoAccept,
+          })
+          .where('equipment_id', id)
+          .returning('*');
+
+        return equipmentRecord;
       })
-      .where('equipment_id', id)
-      .returning('*');
+      .catch((error) => {
+        logger.logException(
+          `Could not update equipment with id '${id}'`,
+          error
+        );
+
+        throw new Error(error);
+      });
 
     return equipmentRecord ? createEquipmentObject(equipmentRecord) : null;
   }
@@ -137,23 +207,44 @@ export default class PostgresEquipmentDataSource
     return equipmentResponsibleRecords.map(createEquipmentResponsibleObject);
   }
 
+  async getEquipmentInstruments(
+    equipmentId: number
+  ): Promise<EquipmentInstrument[]> {
+    const equipmentInstrumentsRecords =
+      await database<EquipmentInstrumentRecord>(this.equipmentInstrumentsTable)
+        .select('*')
+        .where('equipment_id', equipmentId);
+
+    return equipmentInstrumentsRecords.map(createEquipmentInstrumentObject);
+  }
+
   async availableEquipments(
     scheduledEvent: ScheduledEvent
   ): Promise<Equipment[]> {
     /**
      * This queries tries to find every available equipments by checking:
+     *  - the scheduled event instrument is part of equipment instruments
      *  - the equipment is not under scheduled maintenance:
      *    * maintenance_starts_at is NULL
      *    * maintenance_starts_at is not NULL but maintenance_ends_at is NULL, under maintenance indefinitely
      *    * maintenance_starts_at and maintenance_ends_at overlaps with the scheduled event
-     *  - we have no relationship between the scheduled vent and the equipment
+     *  - we have no relationship between the scheduled event and the equipment
      *  - the scheduled event doesn't overlap with other assigned scheduled events
      */
     const equipmentRecords = await database<EquipmentRecord>(this.tableName)
       .select<EquipmentRecord[]>(`${this.tableName}.*`)
+      .join(
+        this.equipmentInstrumentsTable,
+        `${this.tableName}.equipment_id`,
+        `${this.equipmentInstrumentsTable}.equipment_id`
+      )
+      .where(
+        `${this.equipmentInstrumentsTable}.instrument_id`,
+        scheduledEvent.instrument.id
+      )
       .whereRaw(
         // TODO: see if we can use knex QB instead of raw
-        `equipment_id NOT IN (
+        `${this.tableName}.equipment_id NOT IN (
           SELECT eq.equipment_id 
           FROM ${this.tableName} eq 
           INNER JOIN ${this.scheduledEventsEquipmentsTable} see ON see.equipment_id = eq.equipment_id 
@@ -242,9 +333,35 @@ export default class PostgresEquipmentDataSource
 
   async assign(input: AssignEquipmentsToScheduledEventInput): Promise<boolean> {
     try {
-      const equipments = await database<EquipmentRecord>(this.tableName)
-        .select('equipment_id', 'auto_accept')
-        .whereIn('equipment_id', input.equipmentIds);
+      const [scheduledEvent] = await database<ScheduledEventRecord>(
+        this.scheduledEventsTable
+      )
+        .select('instrument_id')
+        .where('scheduled_event_id', input.scheduledEventId);
+
+      const equipments = await database<
+        EquipmentRecord & EquipmentInstrumentRecord
+      >(this.tableName)
+        .select(
+          `${this.tableName}.equipment_id`,
+          'auto_accept',
+          'instrument_id'
+        )
+        .join(
+          this.equipmentInstrumentsTable,
+          `${this.tableName}.equipment_id`,
+          `${this.equipmentInstrumentsTable}.equipment_id`
+        )
+        .whereIn(`${this.tableName}.equipment_id`, input.equipmentIds)
+        .andWhere('instrument_id', scheduledEvent.instrument_id);
+
+      // NOTE: We check to see if all equipments can be used on the scheduled event instrument
+      if (equipments.length !== input.equipmentIds.length) {
+        throw new ApolloError(
+          'Some of the equipments can not be used on scheduled event instrument',
+          'NOT_ALLOWED'
+        );
+      }
 
       const records = await database<EquipmentsScheduledEventsRecord>(
         this.scheduledEventsEquipmentsTable

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -1,5 +1,9 @@
 import { ProposalBookingStatusCore } from '../../generated/sdk';
-import { Equipment, EquipmentResponsible } from '../../models/Equipment';
+import {
+  Equipment,
+  EquipmentInstrument,
+  EquipmentResponsible,
+} from '../../models/Equipment';
 import { LostTime } from '../../models/LostTime';
 import { ProposalBooking } from '../../models/ProposalBooking';
 import {
@@ -113,6 +117,11 @@ export interface EquipmentResponsibleRecord {
   readonly user_id: number;
 }
 
+export interface EquipmentInstrumentRecord {
+  readonly equipment_id: number;
+  readonly instrument_id: number;
+}
+
 export const createEquipmentObject = (equipment: EquipmentRecord) =>
   new Equipment(
     equipment.equipment_id,
@@ -130,6 +139,10 @@ export const createEquipmentObject = (equipment: EquipmentRecord) =>
 export const createEquipmentResponsibleObject = (
   equipmentResponsible: EquipmentResponsibleRecord
 ) => new EquipmentResponsible(equipmentResponsible.user_id);
+
+export const createEquipmentInstrumentObject = (
+  equipmentInstrument: EquipmentInstrumentRecord
+) => new EquipmentInstrument(equipmentInstrument.instrument_id);
 
 export interface EquipmentsScheduledEventsRecord {
   readonly equipment_id: number;

--- a/src/models/Equipment.ts
+++ b/src/models/Equipment.ts
@@ -21,3 +21,7 @@ export class Equipment {
 export class EquipmentResponsible {
   constructor(public id: number) {}
 }
+
+export class EquipmentInstrument {
+  constructor(public id: number) {}
+}

--- a/src/queries/EquipmentQueries.ts
+++ b/src/queries/EquipmentQueries.ts
@@ -7,6 +7,7 @@ import { isUserOfficer } from '../helpers/permissionHelpers';
 import {
   Equipment,
   EquipmentAssignmentStatus,
+  EquipmentInstrument,
   EquipmentResponsible,
 } from '../models/Equipment';
 import { Roles } from '../types/shared';
@@ -96,5 +97,13 @@ export default class EquipmentQueries {
     equipmentId: number
   ): Promise<EquipmentResponsible[]> {
     return this.equipmentDataSource.getEquipmentResponsible(equipmentId);
+  }
+
+  @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST]) // TODO: make sure we use the right permissions
+  getEquipmentInstruments(
+    ctx: ResolverContext,
+    equipmentId: number
+  ): Promise<EquipmentInstrument[]> {
+    return this.equipmentDataSource.getEquipmentInstruments(equipmentId);
   }
 }

--- a/src/resolvers/mutations/EquipmentMutation.ts
+++ b/src/resolvers/mutations/EquipmentMutation.ts
@@ -25,6 +25,9 @@ export class EquipmentInput implements Partial<EquipmentBase> {
   @Field(() => String)
   description: string;
 
+  @Field(() => [Int])
+  instrumentIds: number[];
+
   @Field(() => String, { nullable: true })
   color: string | null;
 

--- a/src/resolvers/mutations/EquipmentMutation.ts
+++ b/src/resolvers/mutations/EquipmentMutation.ts
@@ -25,8 +25,8 @@ export class EquipmentInput implements Partial<EquipmentBase> {
   @Field(() => String)
   description: string;
 
-  @Field(() => [Int])
-  instrumentIds: number[];
+  @Field(() => [Int], { nullable: true })
+  instrumentIds?: number[];
 
   @Field(() => String, { nullable: true })
   color: string | null;

--- a/src/resolvers/types/Equipment.ts
+++ b/src/resolvers/types/Equipment.ts
@@ -16,6 +16,7 @@ import {
   EquipmentAssignmentStatus,
 } from '../../models/Equipment';
 import { TzLessDateTime } from '../CustomScalars';
+import { Instrument } from './Instrument';
 import { ScheduledEvent } from './ScheduledEvent';
 import { User } from './User';
 
@@ -83,5 +84,13 @@ export class EquipmentResolvers {
     @Ctx() ctx: ResolverContext
   ): Promise<User[]> {
     return ctx.queries.equipment.getEquipmentResponsible(ctx, equipment.id);
+  }
+
+  @FieldResolver(() => [Instrument])
+  equipmentInstruments(
+    @Root() equipment: Equipment,
+    @Ctx() ctx: ResolverContext
+  ): Promise<Instrument[]> {
+    return ctx.queries.equipment.getEquipmentInstruments(ctx, equipment.id);
   }
 }


### PR DESCRIPTION
## Description

- Added new table for instruments assigned to equipment which defines where the given equipment should be used
- Limited the equipment shown per scheduled event to equipment assigned to the events instrument
- Prevented removing instruments from equipment if there are equipment events booked on one of the removed instruments

## Motivation and Context

Previously every equipment was available to all the instruments. This could become a bit messy because not every equipment should be used with any instrument. This prevents that kind of mess.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

- https://jira.esss.lu.se/browse/SWAP-2195

## Changes

https://user-images.githubusercontent.com/6333063/151987365-91be5905-257a-4eb8-979a-6ffaae16192b.mp4

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
