### PR TITLE
feat: Scheduler API access token using permissions defined in core

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -9,7 +9,7 @@ import LostTimeQueries from '../queries/LostTimeQueries';
 import ProposalBookingQueries from '../queries/ProposalBookingQueries';
 import ScheduledEventQueries from '../queries/ScheduledEventQueries';
 import SystemQueries from '../queries/SystemQueries';
-import { User, Role } from '../types/shared';
+import { Role, UserWithAccessPermissions } from '../types/shared';
 
 interface ResolverContextMutations {
   equipment: EquipmentMutations;
@@ -32,7 +32,7 @@ export interface BasicResolverContext {
   queries: ResolverContextQueries;
   mutations: ResolverContextMutations;
   currentRole?: Role;
-  user?: User;
+  user?: UserWithAccessPermissions | null;
   roles?: Role[];
   clients: {
     userOffice: () => Sdk;

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,4 +1,4 @@
-import { getSdk } from '../generated/sdk';
+import { Sdk } from '../generated/sdk';
 import EquipmentMutations from '../mutations/EquipmentMutations';
 import LostTimeMutations from '../mutations/LostTimeMutations';
 import ProposalBookingMutations from '../mutations/ProposalBookingMutations';
@@ -35,7 +35,7 @@ export interface BasicResolverContext {
   user?: User;
   roles?: Role[];
   clients: {
-    userOffice: () => ReturnType<typeof getSdk>;
+    userOffice: () => Sdk;
   };
 }
 

--- a/src/decorators/Authorized.ts
+++ b/src/decorators/Authorized.ts
@@ -21,13 +21,9 @@ const Authorized = (roles: Roles[] = []) => {
       const [ctx] = args;
       const isMutation = target.constructor.name.includes('Mutation');
 
-      console.log(ctx);
-
-      if ((ctx?.user as any).isApiAccessToken) {
+      if (ctx.user?.isApiAccessToken) {
         if (
-          (ctx?.user as any).accessPermissions?.[
-            `${target.constructor.name}.${name}`
-          ]
+          ctx.user.accessPermissions?.[`${target.constructor.name}.${name}`]
         ) {
           return await originalMethod?.apply(this, args);
         } else {

--- a/src/decorators/Authorized.ts
+++ b/src/decorators/Authorized.ts
@@ -2,6 +2,7 @@
 import { AuthenticationError, ApolloError } from 'apollo-server';
 
 import { ResolverContext } from '../context';
+import { rejection } from '../rejection';
 import { Roles } from '../types/shared';
 import { hasRole } from '../utils/authorization';
 
@@ -18,6 +19,21 @@ const Authorized = (roles: Roles[] = []) => {
 
     descriptor.value = async function (...args) {
       const [ctx] = args;
+      const isMutation = target.constructor.name.includes('Mutation');
+
+      console.log(ctx);
+
+      if ((ctx?.user as any).isApiAccessToken) {
+        if (
+          (ctx?.user as any).accessPermissions?.[
+            `${target.constructor.name}.${name}`
+          ]
+        ) {
+          return await originalMethod?.apply(this, args);
+        } else {
+          return isMutation ? rejection('INSUFFICIENT_PERMISSIONS') : null;
+        }
+      }
 
       if (!ctx.user || !ctx.roles) {
         throw new AuthenticationError('Not authenticated');

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -13,7 +13,6 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: any;
   IntStringDateBoolArray: any;
   _Any: any;
@@ -102,7 +101,7 @@ export type AuthJwtApiTokenPayload = {
 export type AuthJwtPayload = {
   currentRole: Role;
   roles: Array<Role>;
-  user: User;
+  user: UserJwt;
 };
 
 export type BasicUserDetails = {
@@ -426,8 +425,8 @@ export type Feature = {
 export enum FeatureId {
   EMAIL_INVITE = 'EMAIL_INVITE',
   EMAIL_SEARCH = 'EMAIL_SEARCH',
-  EXTERNAL_AUTH = 'EXTERNAL_AUTH',
   INSTRUMENT_MANAGEMENT = 'INSTRUMENT_MANAGEMENT',
+  OAUTH = 'OAUTH',
   RISK_ASSESSMENT = 'RISK_ASSESSMENT',
   SAMPLE_SAFETY = 'SAMPLE_SAFETY',
   SCHEDULER = 'SCHEDULER',
@@ -586,6 +585,7 @@ export type InstitutionResponseWrap = {
 
 export type InstitutionsFilter = {
   isVerified?: InputMaybe<Scalars['Boolean']>;
+  name?: InputMaybe<Scalars['String']>;
 };
 
 export type Instrument = {
@@ -627,11 +627,6 @@ export type IntervalConfig = {
   units: Array<Unit>;
 };
 
-export type LogoutTokenWrap = {
-  rejection: Maybe<Rejection>;
-  token: Maybe<Scalars['String']>;
-};
-
 export type MoveProposalWorkflowStatusInput = {
   from: IndexWithGroupId;
   proposalWorkflowId: Scalars['Int'];
@@ -652,7 +647,7 @@ export type Mutation = {
   assignChairOrSecretary: SepResponseWrap;
   assignInstrumentsToCall: CallResponseWrap;
   assignProposalsToInstrument: SuccessResponseWrap;
-  assignProposalsToSep: NextProposalStatusResponseWrap;
+  assignProposalsToSep: SuccessResponseWrap;
   assignReviewersToSEP: SepResponseWrap;
   assignScientistsToInstrument: SuccessResponseWrap;
   assignSepReviewersToProposal: SepResponseWrap;
@@ -717,8 +712,7 @@ export type Mutation = {
   importProposal: ProposalResponseWrap;
   importTemplate: TemplateResponseWrap;
   importUnits: UnitsResponseWrap;
-  login: TokenResponseWrap;
-  logout: LogoutTokenWrap;
+  logout: TokenResponseWrap;
   mergeInstitutions: InstitutionResponseWrap;
   moveProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   notifyProposal: ProposalResponseWrap;
@@ -765,7 +759,7 @@ export type Mutation = {
   updateQuestion: QuestionResponseWrap;
   updateQuestionTemplateRelation: TemplateResponseWrap;
   updateQuestionTemplateRelationSettings: TemplateResponseWrap;
-  updateReview: ReviewWithNextStatusResponseWrap;
+  updateReview: ReviewResponseWrap;
   updateSEP: SepResponseWrap;
   updateSEPTimeAllocation: SepProposalResponseWrap;
   updateSample: SampleResponseWrap;
@@ -1068,15 +1062,12 @@ export type MutationCreateUserArgs = {
   lastname: Scalars['String'];
   middlename?: InputMaybe<Scalars['String']>;
   nationality: Scalars['Int'];
-  orcid: Scalars['String'];
-  orcidHash: Scalars['String'];
   organisation: Scalars['Int'];
   organizationCountry?: InputMaybe<Scalars['Int']>;
   otherOrganisation?: InputMaybe<Scalars['String']>;
   password: Scalars['String'];
   position: Scalars['String'];
   preferredname?: InputMaybe<Scalars['String']>;
-  refreshToken: Scalars['String'];
   telephone: Scalars['String'];
   telephone_alt?: InputMaybe<Scalars['String']>;
   user_title?: InputMaybe<Scalars['String']>;
@@ -1227,6 +1218,7 @@ export type MutationEmailVerificationArgs = {
 
 export type MutationExternalTokenLoginArgs = {
   externalToken: Scalars['String'];
+  redirectUri: Scalars['String'];
 };
 
 
@@ -1256,12 +1248,6 @@ export type MutationImportTemplateArgs = {
 export type MutationImportUnitsArgs = {
   conflictResolutions: Array<ConflictResolution>;
   json: Scalars['String'];
-};
-
-
-export type MutationLoginArgs = {
-  email: Scalars['String'];
-  password: Scalars['String'];
 };
 
 
@@ -1633,14 +1619,12 @@ export type MutationUpdateUserArgs = {
   lastname?: InputMaybe<Scalars['String']>;
   middlename?: InputMaybe<Scalars['String']>;
   nationality?: InputMaybe<Scalars['Int']>;
-  orcid?: InputMaybe<Scalars['String']>;
   organisation?: InputMaybe<Scalars['Int']>;
   organizationCountry?: InputMaybe<Scalars['Int']>;
   otherOrganisation?: InputMaybe<Scalars['String']>;
   placeholder?: InputMaybe<Scalars['String']>;
   position?: InputMaybe<Scalars['String']>;
   preferredname?: InputMaybe<Scalars['String']>;
-  refreshToken?: InputMaybe<Scalars['String']>;
   roles?: InputMaybe<Array<Scalars['Int']>>;
   telephone?: InputMaybe<Scalars['String']>;
   telephone_alt?: InputMaybe<Scalars['String']>;
@@ -1681,19 +1665,6 @@ export type MutationValidateUnitsImportArgs = {
   unitsAsJson: Scalars['String'];
 };
 
-export type NextProposalStatus = {
-  description: Maybe<Scalars['String']>;
-  id: Maybe<Scalars['Int']>;
-  isDefault: Maybe<Scalars['Boolean']>;
-  name: Maybe<Scalars['String']>;
-  shortCode: Maybe<Scalars['String']>;
-};
-
-export type NextProposalStatusResponseWrap = {
-  nextProposalStatus: Maybe<NextProposalStatus>;
-  rejection: Maybe<Rejection>;
-};
-
 export type NumberInputConfig = {
   numberValueConstraint: Maybe<NumberValueConstraint>;
   required: Scalars['Boolean'];
@@ -1709,15 +1680,6 @@ export enum NumberValueConstraint {
   ONLY_POSITIVE = 'ONLY_POSITIVE',
   ONLY_POSITIVE_INTEGER = 'ONLY_POSITIVE_INTEGER'
 }
-
-export type OrcIdInformation = {
-  firstname: Maybe<Scalars['String']>;
-  lastname: Maybe<Scalars['String']>;
-  orcid: Maybe<Scalars['String']>;
-  orcidHash: Maybe<Scalars['String']>;
-  refreshToken: Maybe<Scalars['String']>;
-  token: Maybe<Scalars['String']>;
-};
 
 export type Page = {
   content: Maybe<Scalars['String']>;
@@ -2075,7 +2037,6 @@ export type Query = {
   filesMetadata: Array<FileMetadata>;
   genericTemplate: Maybe<GenericTemplate>;
   genericTemplates: Maybe<Array<GenericTemplate>>;
-  getOrcIDInformation: Maybe<OrcIdInformation>;
   institutions: Maybe<Array<Institution>>;
   instrument: Maybe<Instrument>;
   instrumentScientistHasAccess: Maybe<Scalars['Boolean']>;
@@ -2243,11 +2204,6 @@ export type QueryGenericTemplateArgs = {
 
 export type QueryGenericTemplatesArgs = {
   filter?: InputMaybe<GenericTemplatesFilter>;
-};
-
-
-export type QueryGetOrcIdInformationArgs = {
-  authorizationCode: Scalars['String'];
 };
 
 
@@ -2656,23 +2612,6 @@ export enum ReviewStatus {
   SUBMITTED = 'SUBMITTED'
 }
 
-export type ReviewWithNextProposalStatus = {
-  comment: Maybe<Scalars['String']>;
-  grade: Maybe<Scalars['Int']>;
-  id: Scalars['Int'];
-  nextProposalStatus: Maybe<NextProposalStatus>;
-  proposal: Maybe<Proposal>;
-  reviewer: Maybe<BasicUserDetails>;
-  sepID: Scalars['Int'];
-  status: ReviewStatus;
-  userID: Scalars['Int'];
-};
-
-export type ReviewWithNextStatusResponseWrap = {
-  rejection: Maybe<Rejection>;
-  review: Maybe<ReviewWithNextProposalStatus>;
-};
-
 export enum ReviewerFilter {
   ALL = 'ALL',
   ME = 'ME'
@@ -2909,6 +2848,7 @@ export enum SettingsId {
   DEFAULT_INST_SCI_REVIEWER_FILTER = 'DEFAULT_INST_SCI_REVIEWER_FILTER',
   DEFAULT_INST_SCI_STATUS_FILTER = 'DEFAULT_INST_SCI_STATUS_FILTER',
   EXTERNAL_AUTH_LOGIN_URL = 'EXTERNAL_AUTH_LOGIN_URL',
+  EXTERNAL_AUTH_LOGOUT_URL = 'EXTERNAL_AUTH_LOGOUT_URL',
   FEEDBACK_EXHAUST_DAYS = 'FEEDBACK_EXHAUST_DAYS',
   FEEDBACK_FREQUENCY_DAYS = 'FEEDBACK_FREQUENCY_DAYS',
   FEEDBACK_MAX_REQUESTS = 'FEEDBACK_MAX_REQUESTS',
@@ -3301,13 +3241,13 @@ export type User = {
   lastname: Scalars['String'];
   middlename: Maybe<Scalars['String']>;
   nationality: Maybe<Scalars['Int']>;
-  orcid: Scalars['String'];
+  oauthRefreshToken: Maybe<Scalars['String']>;
+  oidcSub: Maybe<Scalars['String']>;
   organisation: Scalars['Int'];
   placeholder: Scalars['Boolean'];
   position: Scalars['String'];
   preferredname: Maybe<Scalars['String']>;
   proposals: Array<Proposal>;
-  refreshToken: Scalars['String'];
   reviews: Array<Review>;
   roles: Array<Role>;
   seps: Array<Sep>;
@@ -3329,6 +3269,19 @@ export type UserReviewsArgs = {
   instrumentId?: InputMaybe<Scalars['Int']>;
   reviewer?: InputMaybe<ReviewerFilter>;
   status?: InputMaybe<ReviewStatus>;
+};
+
+export type UserJwt = {
+  created: Scalars['String'];
+  email: Scalars['String'];
+  firstname: Scalars['String'];
+  id: Scalars['Int'];
+  lastname: Scalars['String'];
+  oidcSub: Maybe<Scalars['String']>;
+  organisation: Scalars['Float'];
+  placeholder: Scalars['Boolean'];
+  position: Scalars['String'];
+  preferredname: Maybe<Scalars['String']>;
 };
 
 export type UserProposalsFilter = {
@@ -3418,6 +3371,13 @@ export type _Service = {
   sdl: Maybe<Scalars['String']>;
 };
 
+export type GetAccessTokenAndPermissionsQueryVariables = Exact<{
+  accessTokenId: Scalars['String'];
+}>;
+
+
+export type GetAccessTokenAndPermissionsQuery = { accessTokenAndPermissions: { id: string, accessPermissions: string } | null };
+
 export type InstrumentScientistHasAccessQueryVariables = Exact<{
   proposalPk: Scalars['Int'];
   instrumentId: Scalars['Int'];
@@ -3446,6 +3406,14 @@ export type UserHasAccessQueryVariables = Exact<{
 export type UserHasAccessQuery = { userHasAccessToProposal: boolean | null };
 
 
+export const GetAccessTokenAndPermissionsDocument = gql`
+    query getAccessTokenAndPermissions($accessTokenId: String!) {
+  accessTokenAndPermissions(accessTokenId: $accessTokenId) {
+    id
+    accessPermissions
+  }
+}
+    `;
 export const InstrumentScientistHasAccessDocument = gql`
     query instrumentScientistHasAccess($proposalPk: Int!, $instrumentId: Int!) {
   instrumentScientistHasAccess(
@@ -3481,6 +3449,9 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
+    getAccessTokenAndPermissions(variables: GetAccessTokenAndPermissionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetAccessTokenAndPermissionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetAccessTokenAndPermissionsQuery>(GetAccessTokenAndPermissionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getAccessTokenAndPermissions', 'query');
+    },
     instrumentScientistHasAccess(variables: InstrumentScientistHasAccessQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InstrumentScientistHasAccessQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<InstrumentScientistHasAccessQuery>(InstrumentScientistHasAccessDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'instrumentScientistHasAccess', 'query');
     },

--- a/src/graphql/apiAccessToken/accessTokenAndPermissions.graphql
+++ b/src/graphql/apiAccessToken/accessTokenAndPermissions.graphql
@@ -1,0 +1,6 @@
+query getAccessTokenAndPermissions($accessTokenId: String!) {
+  accessTokenAndPermissions(accessTokenId: $accessTokenId) {
+    id
+    accessPermissions
+  }
+}

--- a/src/helpers/instrumentHelpers.ts
+++ b/src/helpers/instrumentHelpers.ts
@@ -7,7 +7,7 @@ export async function instrumentScientistHasInstrument(
   ctx: ResolverContext,
   instrumentId: number
 ): Promise<boolean> {
-  if (!hasRole([Roles.USER_OFFICER], ctx.roles!)) {
+  if (!hasRole([Roles.USER_OFFICER], ctx.roles)) {
     const { instrumentScientistHasInstrument } = await ctx.clients
       .userOffice()
       .instrumentScientistHasInstrument({

--- a/src/helpers/permissionHelpers.ts
+++ b/src/helpers/permissionHelpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ResolverContext } from '../context';
 import { ProposalBooking } from '../models/ProposalBooking';
 import { Roles } from '../types/shared';
@@ -23,11 +22,11 @@ export async function instrumentScientistHasAccess(
     return false;
   }
 
-  if (hasRole([Roles.USER_OFFICER], ctx.roles!)) {
+  if (hasRole([Roles.USER_OFFICER], ctx.roles)) {
     return true;
   }
 
-  if (!hasRole([Roles.INSTRUMENT_SCIENTIST], ctx.roles!)) {
+  if (!hasRole([Roles.INSTRUMENT_SCIENTIST], ctx.roles)) {
     return false;
   }
 
@@ -64,11 +63,11 @@ export async function userHacAccess(
     return false;
   }
 
-  if (hasRole([Roles.USER_OFFICER], ctx.roles!)) {
+  if (hasRole([Roles.USER_OFFICER], ctx.roles)) {
     return true;
   }
 
-  if (!hasRole([Roles.USER], ctx.roles!)) {
+  if (!hasRole([Roles.USER], ctx.roles)) {
     return false;
   }
 
@@ -94,7 +93,7 @@ export function isUserOfficer(agent: ResolverContext | null) {
 }
 
 export function isApiToken(agent: ResolverContext | null) {
-  return (agent?.user as any)?.isApiAccessToken;
+  return agent?.user?.isApiAccessToken;
 }
 
 export function isEquipmentResponsibleOrOwner(

--- a/src/helpers/permissionHelpers.ts
+++ b/src/helpers/permissionHelpers.ts
@@ -93,6 +93,10 @@ export function isUserOfficer(agent: ResolverContext | null) {
   return agent?.currentRole?.shortCode === Roles.USER_OFFICER;
 }
 
+export function isApiToken(agent: ResolverContext | null) {
+  return (agent?.user as any)?.isApiAccessToken;
+}
+
 export function isEquipmentResponsibleOrOwner(
   agent: ResolverContext | null,
   userIds: number[]

--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -73,14 +73,25 @@ const apolloServer = async (app: Express) => {
 
           if (authJwtPayload) {
             if (authJwtPayload && 'accessTokenId' in authJwtPayload) {
-              throw new Error(
-                'Accessing the Scheduler with API token is not supported yet'
-              );
-            }
+              const { accessTokenAndPermissions } = await context.clients
+                .userOffice()
+                .getAccessTokenAndPermissions({
+                  accessTokenId: authJwtPayload.accessTokenId,
+                });
 
-            context.user = authJwtPayload?.user;
-            context.roles = authJwtPayload?.roles;
-            context.currentRole = authJwtPayload?.currentRole;
+              const user = {
+                accessPermissions: accessTokenAndPermissions?.accessPermissions
+                  ? JSON.parse(accessTokenAndPermissions.accessPermissions)
+                  : null,
+                isApiAccessToken: true,
+              } as any;
+
+              context.user = user;
+            } else {
+              context.user = authJwtPayload?.user;
+              context.roles = authJwtPayload?.roles;
+              context.currentRole = authJwtPayload?.currentRole;
+            }
           }
         } catch (error) {
           logger.logException('failed to decode token', error);

--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -11,10 +11,11 @@ import jsonwebtoken from 'jsonwebtoken';
 
 import baseContext from '../buildContext';
 import { ResolverContext } from '../context';
+import { AuthJwtApiTokenPayload, AuthJwtPayload } from '../generated/sdk';
 import initGraphQLClient from '../graphql/client';
 import federationSources from '../resolvers/federationSources';
 import { registerEnums } from '../resolvers/registerEnums';
-import { AuthJwtPayload, AuthJwtApiTokenPayload } from '../types/shared';
+import { UserWithAccessPermissions } from '../types/shared';
 import { buildFederatedSchema } from '../utils/buildFederatedSchema';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -84,7 +85,7 @@ const apolloServer = async (app: Express) => {
                   ? JSON.parse(accessTokenAndPermissions.accessPermissions)
                   : null,
                 isApiAccessToken: true,
-              } as any;
+              } as UserWithAccessPermissions;
 
               context.user = user;
             } else {
@@ -94,7 +95,7 @@ const apolloServer = async (app: Express) => {
             }
           }
         } catch (error) {
-          logger.logException('failed to decode token', error);
+          logger.logException('Context creation error', error);
           throw error;
         }
       }

--- a/src/queries/EquipmentQueries.ts
+++ b/src/queries/EquipmentQueries.ts
@@ -3,7 +3,7 @@ import { EquipmentDataSource } from '../datasources/EquipmentDataSource';
 import { ScheduledEventDataSource } from '../datasources/ScheduledEventDataSource';
 import Authorized from '../decorators/Authorized';
 import { getUserInstruments } from '../helpers/instrumentHelpers';
-import { isUserOfficer } from '../helpers/permissionHelpers';
+import { isApiToken, isUserOfficer } from '../helpers/permissionHelpers';
 import {
   Equipment,
   EquipmentAssignmentStatus,
@@ -31,7 +31,7 @@ export default class EquipmentQueries {
     ctx: ResolverContext,
     equipmentIds?: number[]
   ): Promise<Equipment[]> {
-    if (isUserOfficer(ctx)) {
+    if (isUserOfficer(ctx) || isApiToken(ctx)) {
       const allEquipments = this.equipmentDataSource.getAll(equipmentIds);
 
       return allEquipments;

--- a/src/queries/LostTimeQueries.ts
+++ b/src/queries/LostTimeQueries.ts
@@ -1,7 +1,10 @@
 import { ResolverContext } from '../context';
 import { LostTimeDataSource } from '../datasources/LostTimeDataSource';
 import Authorized from '../decorators/Authorized';
-import { instrumentScientistHasAccess } from '../helpers/permissionHelpers';
+import {
+  instrumentScientistHasAccess,
+  isApiToken,
+} from '../helpers/permissionHelpers';
 import { LostTime } from '../models/LostTime';
 import { Roles } from '../types/shared';
 
@@ -19,7 +22,10 @@ export default class LostTimeQueries {
       scheduledEventId?: number;
     }
   ): Promise<LostTime[]> {
-    if (!(await instrumentScientistHasAccess(ctx, proposalBookingId))) {
+    if (
+      !(await instrumentScientistHasAccess(ctx, proposalBookingId)) &&
+      !isApiToken(ctx)
+    ) {
       return [];
     }
 

--- a/src/queries/ProposalBookingQueries.ts
+++ b/src/queries/ProposalBookingQueries.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ResolverContext } from '../context';
 import { ProposalBookingDataSource } from '../datasources/ProposalBookingDataSource';
 import Authorized from '../decorators/Authorized';
@@ -65,9 +64,7 @@ export default class ProposalBookingQueries {
     filter?: ProposalProposalBookingFilter
   ): Promise<ProposalBooking | null> {
     // don't show proposal bookings is draft state for users
-    if (
-      !hasRole([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST], ctx.roles!)
-    ) {
+    if (!hasRole([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST], ctx.roles)) {
       filter = {
         status: [
           ProposalBookingStatusCore.ACTIVE,
@@ -85,7 +82,8 @@ export default class ProposalBookingQueries {
 
     if (
       !(await instrumentScientistHasAccess(ctx, proposalBooking)) &&
-      !(await userHacAccess(ctx, proposalBooking))
+      !(await userHacAccess(ctx, proposalBooking)) &&
+      !isApiToken(ctx)
     ) {
       return null;
     }

--- a/src/queries/ProposalBookingQueries.ts
+++ b/src/queries/ProposalBookingQueries.ts
@@ -6,6 +6,7 @@ import { ProposalBookingStatusCore } from '../generated/sdk';
 import { instrumentScientistHasInstrument } from '../helpers/instrumentHelpers';
 import {
   instrumentScientistHasAccess,
+  isApiToken,
   userHacAccess,
 } from '../helpers/permissionHelpers';
 import { ProposalBooking } from '../models/ProposalBooking';
@@ -24,7 +25,8 @@ export default class ProposalBookingQueries {
     const results = await Promise.all(
       instrumentIds.map(
         async (instrumentId) =>
-          await instrumentScientistHasInstrument(ctx, instrumentId)
+          (await instrumentScientistHasInstrument(ctx, instrumentId)) ||
+          isApiToken(ctx)
       )
     );
 
@@ -47,7 +49,8 @@ export default class ProposalBookingQueries {
 
     if (
       !(await instrumentScientistHasAccess(ctx, proposalBooking)) &&
-      !(await userHacAccess(ctx, proposalBooking))
+      !(await userHacAccess(ctx, proposalBooking)) &&
+      !isApiToken(ctx)
     ) {
       return null;
     }

--- a/src/queries/ScheduledEventQueries.ts
+++ b/src/queries/ScheduledEventQueries.ts
@@ -4,6 +4,7 @@ import Authorized from '../decorators/Authorized';
 import { instrumentScientistHasInstrument } from '../helpers/instrumentHelpers';
 import {
   instrumentScientistHasAccess,
+  isApiToken,
   isUserOfficer,
   userHacAccess,
 } from '../helpers/permissionHelpers';
@@ -61,7 +62,8 @@ export default class ScheduledEventQueries {
   ): Promise<ScheduledEvent[]> {
     if (
       !(await instrumentScientistHasAccess(ctx, proposalBookingId)) &&
-      !(await userHacAccess(ctx, proposalBookingId))
+      !(await userHacAccess(ctx, proposalBookingId)) &&
+      !isApiToken(ctx)
     ) {
       return [];
     }

--- a/src/queries/ScheduledEventQueries.ts
+++ b/src/queries/ScheduledEventQueries.ts
@@ -80,7 +80,10 @@ export default class ScheduledEventQueries {
     proposalBookingId: number,
     scheduledEventId: number
   ): Promise<ScheduledEvent | null> {
-    if (!(await instrumentScientistHasAccess(ctx, proposalBookingId))) {
+    if (
+      !(await instrumentScientistHasAccess(ctx, proposalBookingId)) &&
+      !isApiToken(ctx)
+    ) {
       return null;
     }
 
@@ -97,8 +100,8 @@ export default class ScheduledEventQueries {
     startsAt: Date,
     endsAt: Date
   ) {
-    // NOTE: For USER_OFFICER send null to recieve all equipment events
-    const userId = isUserOfficer(ctx) ? null : ctx.user?.id;
+    // NOTE: For USER_OFFICER and API access send null to recieve all equipment events
+    const userId = isUserOfficer(ctx) || isApiToken(ctx) ? null : ctx.user?.id;
 
     return this.scheduledEventDataSource.equipmentScheduledEvents(
       equipmentIds,

--- a/src/queries/SystemQueries.ts
+++ b/src/queries/SystemQueries.ts
@@ -41,8 +41,7 @@ export default class SystemQueries {
       const proto = Object.getPrototypeOf(element);
       if (!proto.constructor.name.startsWith('System')) {
         const names = Object.getOwnPropertyNames(proto).filter(
-          (item) =>
-            item !== 'constructor' || item.constructor.name.startsWith('System')
+          (item) => item !== 'constructor'
         );
 
         const classNamesWithMethod = names.map(

--- a/src/queries/SystemQueries.ts
+++ b/src/queries/SystemQueries.ts
@@ -1,10 +1,58 @@
+import { ResolverContext } from '../context';
 import { SystemDataSource } from '../datasources/SystemDataSource';
+import Authorized from '../decorators/Authorized';
 import { HealthStats } from '../resolvers/queries/SystemQuery';
+import { Roles } from '../types/shared';
 
 export default class SystemQueries {
   constructor(private systemDataSource: SystemDataSource) {}
 
   async healthCheck(): Promise<HealthStats> {
     return this.systemDataSource.healthCheck();
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async getAllQueryAndMutationMethods(context: ResolverContext) {
+    const allQueryMethods: string[] = [];
+    const allMutationMethods: string[] = [];
+
+    Object.keys(context.queries).forEach((queryKey) => {
+      const element =
+        context.queries[queryKey as keyof ResolverContext['queries']];
+
+      const proto = Object.getPrototypeOf(element);
+      if (!proto.constructor.name.startsWith('System')) {
+        const names = Object.getOwnPropertyNames(proto).filter(
+          (item) => item !== 'constructor'
+        );
+
+        const classNamesWithMethod = names.map(
+          (item) => `${proto.constructor.name}.${item}`
+        );
+
+        allQueryMethods.push(...classNamesWithMethod);
+      }
+    });
+
+    Object.keys(context.mutations).forEach((mutationKey) => {
+      const element =
+        context.mutations[mutationKey as keyof ResolverContext['mutations']];
+
+      const proto = Object.getPrototypeOf(element);
+      if (!proto.constructor.name.startsWith('System')) {
+        const names = Object.getOwnPropertyNames(proto).filter(
+          (item) =>
+            item !== 'constructor' || item.constructor.name.startsWith('System')
+        );
+
+        const classNamesWithMethod = names.map(
+          (item) => `${proto.constructor.name}.${item}`
+        );
+
+        allMutationMethods.push(...classNamesWithMethod);
+      }
+    });
+
+    return { queries: allQueryMethods, mutations: allMutationMethods };
   }
 }

--- a/src/resolvers/queries/SystemQuery.ts
+++ b/src/resolvers/queries/SystemQuery.ts
@@ -41,6 +41,15 @@ export class SchedulerConfig {
 
 let cachedVersion: string;
 
+@ObjectType()
+export class QueriesAndMutations {
+  @Field(() => [String])
+  public queries: string[];
+
+  @Field(() => [String])
+  public mutations: string[];
+}
+
 @Resolver()
 export class SystemQuery {
   @Query(() => HealthStats)
@@ -81,5 +90,10 @@ export class SystemQuery {
 
       return '<unknown>';
     }
+  }
+
+  @Query(() => QueriesAndMutations, { nullable: true })
+  async schedulerQueriesAndMutations(@Ctx() context: ResolverContext) {
+    return context.queries.system.getAllQueryAndMutationMethods(context);
   }
 }

--- a/src/resolvers/types/Equipment.ts
+++ b/src/resolvers/types/Equipment.ts
@@ -63,7 +63,7 @@ export class EquipmentWithAssignmentStatus extends Equipment {
 
 @Resolver(() => Equipment)
 export class EquipmentResolvers {
-  @FieldResolver(() => [ScheduledEvent])
+  @FieldResolver(() => [ScheduledEvent], { nullable: true })
   events(
     @Root() equipment: Equipment,
     @Ctx() ctx: ResolverContext,

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -17,5 +17,7 @@ export type User = {
   email: string;
 };
 
-export type AuthJwtPayload = { user: User; roles: Role[]; currentRole: Role };
-export type AuthJwtApiTokenPayload = { accessTokenId: string };
+export interface UserWithAccessPermissions extends User {
+  accessPermissions?: Record<string, boolean>;
+  isApiAccessToken?: boolean;
+}

--- a/src/utils/authorization.ts
+++ b/src/utils/authorization.ts
@@ -2,14 +2,14 @@ import { Roles, Role } from '../types/shared';
 
 export function hasRole(
   requiredRoles: Roles[],
-  availableRoles: Role[]
+  availableRoles?: Role[]
 ): boolean {
   if (requiredRoles.length === 0) {
     return true;
   }
 
   return requiredRoles.some((requiredRole) =>
-    availableRoles.some(
+    availableRoles?.some(
       (availableRole) => requiredRole === availableRole.shortCode
     )
   );


### PR DESCRIPTION
## Description

There was a need to access scheduler by API access tokens. We added connection between the core and the scheduler where user office core can query all the mutations and queries from the scheduler and include them in the API access token generation if scheduler is enabled. Scheduler also implements all the logic needed to work with these tokens and validate them correctly, the same way as it is done in the core.

## Motivation and Context

The user office core allowed access with an API access token but scheduler wasn't included in this. Now we make scheduler to work with access token generated in the core with correct access rules.

## How Has This Been Tested

* Manual testing

## Fixes

* https://jira.esss.lu.se/browse/SWAP-2811
* https://jira.esss.lu.se/browse/SWAP-2875

## Changes

https://user-images.githubusercontent.com/6333063/199691326-f20e84aa-765d-43d7-bef7-afe29e48d9ba.mp4

## Depends on

https://github.com/UserOfficeProject/user-office-core/pull/96

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
