### PR TITLE
chore: exclude pushing to dockerhub if dependabot is creating the PR

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,6 +43,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # Don't push the built image if dependabot is creating the PR
+    if: github.actor != 'dependabot[bot]'
     needs: test
 
     steps:
@@ -62,8 +64,6 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
-        # Don't push the built image if dependabot is creating the PR
-        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -74,8 +74,6 @@ jobs:
         run: echo "Extracted branch ${{ github.head_ref }}"
 
       - name: Build and push
-        # Don't push the built image if dependabot is creating the PR
-        if: github.actor != 'dependabot[bot]'
         uses: docker/build-push-action@v2.9.0
         with:
           push: true

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Don't push the built image if dependabot is creating the PR
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     needs: test
 
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Don't push the built image if dependabot is creating the PR
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     needs: test
 
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Don't push the built image if dependabot is creating the PR
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor == 'dependabot[bot]' }}
     needs: test
 
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,6 +62,8 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
+        # Don't push the built image if dependabot is creating the PR
+        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -72,6 +74,8 @@ jobs:
         run: echo "Extracted branch ${{ github.head_ref }}"
 
       - name: Build and push
+        # Don't push the built image if dependabot is creating the PR
+        if: github.actor != 'dependabot[bot]'
         uses: docker/build-push-action@v2.9.0
         with:
           push: true


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Update test-build action to exclude login and push to docker hub if dependabot is creating the PRs