### PR TITLE
chore: Build but not push images from dependabot

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,8 +44,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    # Don't run if dependabot created the PR
-    if: github.actor != 'dependabot[bot]'
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -77,11 +75,10 @@ jobs:
         run: echo "Extracted branch ${{ github.head_ref }}"
 
       - name: Build and push
-        # Don't build and push image if dependabot is creating the PR
-        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/build-push-action@v3
         with:
-          push: true
+          # Don't push if dependabot is creating the PR
+          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
           tags: ghcr.io/userofficeproject/user-office-scheduler-backend:${{ github.head_ref }}
           cache-from: type=local,src=/tmp/.buildx-layer-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-layer-cache


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Let it build to test the docker build operation but do not push and login to the registry